### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+*Unreleased*
+
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 v0.2.0
 ------
 
@@ -42,4 +49,3 @@ v0.1.0
 *Released: 2015-07-27*
 
 - Initial release. [drybjed]
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 v0.2.0
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 v0.2.0
 ------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage local or remote libvirt instance'
   license: 'GNU General Public License v3'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   command: groups
   register: libvirt__register_groups
   changed_when: False
-  check_mode: no
+  check_mode: False
   become: False
   tags: [ 'role::libvirt:networks', 'role::libvirt:pools' ]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   command: groups
   register: libvirt__register_groups
   changed_when: False
-  always_run: True
+  check_mode: no
   become: False
   tags: [ 'role::libvirt:networks', 'role::libvirt:pools' ]
 


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.