### PR TITLE
Added support for macvtap direct connection.

### DIFF
--- a/templates/lookup/network/direct.xml.j2
+++ b/templates/lookup/network/direct.xml.j2
@@ -1,0 +1,9 @@
+<network>
+  <name>{{ item.name }}</name>
+{% if item.uuid|d() %}
+  <uuid>{{ item.uuid }}</uuid>
+{% endif %}
+  <forward mode="bridge">
+    <interface dev="{{ item.bridge }}" />
+  </forward>
+</network>


### PR DESCRIPTION
This adds a new network type to create direct connection between host interfaces and vms interfaces using the macvtap driver.

Exemple:

      libvirt__networks_default:
        - name: 'default'
          type: 'dnsmasq'
          bridge: 'virbr0'
          addresses: [ '192.168.122.1/24' ]
          dhcp_range: [ '2', '-2' ]
          state: 'absent'
        
        - name: 'direct'
          type: 'direct'
          bridge: 'enp6s0'
          state: 'active'
